### PR TITLE
rename ResponseLog to Attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Hello World")
 }
 
-func Logger(l httplogger.ResponseLog, r *http.Request) {
+func Logger(l httplogger.Attrs, r *http.Request) {
 	log.Println("size:", l.RequestSize())
 	log.Println("status:", l.Status())
 	log.Println("method:", r.Method)

--- a/handler.go
+++ b/handler.go
@@ -10,8 +10,13 @@ type private interface {
 	private()
 }
 
-// ResponseLog is the information of the response.
-type ResponseLog interface {
+// ResponseLog is the interface for the response information.
+//
+// Deprecated: Use Attrs instead.
+type ResponseLog = Attrs
+
+// Attrs is the information of the response.
+type Attrs interface {
 	// Header returns HTTP Header of the response.
 	Header() http.Header
 
@@ -45,7 +50,7 @@ type ResponseLog interface {
 
 // Logger is the interface for your custom logger.
 type Logger interface {
-	WriteHTTPLog(l ResponseLog, r *http.Request)
+	WriteHTTPLog(l Attrs, r *http.Request)
 }
 
 type loggingHandler struct {
@@ -79,9 +84,9 @@ func LoggingHandler(logger Logger, handler http.Handler) http.Handler {
 }
 
 // The LoggerFunc type is an adapter to allow the use of ordinary functions as Logger.
-type LoggerFunc func(l ResponseLog, r *http.Request)
+type LoggerFunc func(l Attrs, r *http.Request)
 
 // WriteHTTPLog implements the Logger interface.
-func (f LoggerFunc) WriteHTTPLog(l ResponseLog, r *http.Request) {
+func (f LoggerFunc) WriteHTTPLog(l Attrs, r *http.Request) {
 	f(l, r)
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -16,7 +16,7 @@ func ExampleLoggingHandler() {
 		fmt.Fprint(w, "Hello World")
 	})
 
-	loggingHandler := httplogger.LoggingHandler(httplogger.LoggerFunc(func(l httplogger.ResponseLog, r *http.Request) {
+	loggingHandler := httplogger.LoggingHandler(httplogger.LoggerFunc(func(l httplogger.Attrs, r *http.Request) {
 		fmt.Println("size:", l.ResponseSize())
 		fmt.Println("status:", l.Status())
 		fmt.Println("method:", r.Method)
@@ -59,7 +59,7 @@ func TestHijack(t *testing.T) {
 		}
 	})
 
-	loggingHandler := httplogger.LoggingHandler(httplogger.LoggerFunc(func(l httplogger.ResponseLog, r *http.Request) {
+	loggingHandler := httplogger.LoggingHandler(httplogger.LoggerFunc(func(l httplogger.Attrs, r *http.Request) {
 		if l.Status() != http.StatusSwitchingProtocols {
 			t.Errorf("unexpected status code: %d", l.Status())
 		}

--- a/logger_test.go
+++ b/logger_test.go
@@ -25,7 +25,7 @@ func TestWriteHeader(t *testing.T) {
 		fmt.Fprint(w, "Hello World")
 	})
 
-	loggingHandler := httplogger.LoggingHandler(httplogger.LoggerFunc(func(l httplogger.ResponseLog, r *http.Request) {
+	loggingHandler := httplogger.LoggingHandler(httplogger.LoggerFunc(func(l httplogger.Attrs, r *http.Request) {
 		if l.Status() != http.StatusOK {
 			t.Errorf("unexpected status code: %d", l.Status())
 		}


### PR DESCRIPTION
ResponseLog now contains not only the response information but also the request information.
So we remove "Response" from its name.